### PR TITLE
Update disks.cfg

### DIFF
--- a/pack/services/disks.cfg
+++ b/pack/services/disks.cfg
@@ -1,5 +1,5 @@
 define service{
-   service_description    Disks$KEY$
+   service_description    Disks
    use            1hour_long,aix-service
    register       0
    host_name	  aix


### PR DESCRIPTION
Got this error message trying aix monitoring just now

`[1452259277] ERROR: [Shinken] Disks$KEY$: My service_description got the character $ that is not allowed.`

Removing this `$KEYS$` does the job, just like in linux-snmp's disks.cfg
